### PR TITLE
Add load_cell_probe sensor data; kalico MPC stats

### DIFF
--- a/klipper-types/src/extruder.rs
+++ b/klipper-types/src/extruder.rs
@@ -6,6 +6,32 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct ExtruderControlStats {
+    #[serde(default)]
+    pub power: f64,
+
+    #[serde(default)]
+    pub loss_ambient: f64,
+
+    #[serde(default)]
+    pub loss_filament: f64,
+
+    #[serde(default)]
+    pub temp_ambient: f64,
+
+    #[serde(default)]
+    pub temp_block: f64,
+
+    #[serde(default)]
+    pub temp_sensor: f64,
+
+    #[serde(default)]
+    pub filament_density: f64,
+
+    #[serde(default)]
+    pub filament_heat_capacity: f64,
+}
 /// Status for a single extruder (hotend).
 ///
 /// Klipper supports multiple named extruders (e.g. `extruder`, `extruder1`).
@@ -39,6 +65,9 @@ pub struct ExtruderStats {
     /// Time offset for temperature readings. May be absent in stock Klipper.
     #[serde(default)]
     pub time_offset: Option<f64>,
+
+    #[serde(default)]
+    pub control_stats: Option<ExtruderControlStats>,
 
     /// Captures unknown keys from newer Klipper/Kalico firmware versions.
     #[serde(flatten)]

--- a/klipper-types/src/lib.rs
+++ b/klipper-types/src/lib.rs
@@ -12,6 +12,7 @@ pub mod bed;
 pub mod extruder;
 pub mod fan;
 pub mod heater_bed;
+pub mod load_cell_probe;
 pub mod mcu;
 pub mod print;
 pub mod sensor;
@@ -20,13 +21,13 @@ pub mod system;
 pub mod temperature;
 pub mod toolhead;
 pub mod webhooks;
-pub mod load_cell_probe;
 
 // Re-export primary types at crate root for convenience.
 pub use bed::{ProbeStats, ZTiltStats};
 pub use extruder::ExtruderStats;
 pub use fan::{GenericFanStats, TemperatureFanStats};
 pub use heater_bed::HeaterBedStats;
+pub use load_cell_probe::LoadCellProbeStats;
 pub use mcu::McuStats;
 pub use print::{
     ExcludeObjectStats, PauseResumeStats, PrintJobInfo, PrintStats, VirtualSdCardStats,
@@ -37,4 +38,3 @@ pub use system::SystemStats;
 pub use temperature::TemperatureSensorStats;
 pub use toolhead::{GCodeMoveStats, MotionReportStats, ToolheadStats};
 pub use webhooks::{KlippyState, WebhooksStats};
-pub use load_cell_probe::LoadCellProbeStats;

--- a/klipper-types/src/lib.rs
+++ b/klipper-types/src/lib.rs
@@ -20,6 +20,7 @@ pub mod system;
 pub mod temperature;
 pub mod toolhead;
 pub mod webhooks;
+pub mod load_cell_probe;
 
 // Re-export primary types at crate root for convenience.
 pub use bed::{ProbeStats, ZTiltStats};
@@ -36,3 +37,4 @@ pub use system::SystemStats;
 pub use temperature::TemperatureSensorStats;
 pub use toolhead::{GCodeMoveStats, MotionReportStats, ToolheadStats};
 pub use webhooks::{KlippyState, WebhooksStats};
+pub use load_cell_probe::LoadCellProbeStats;

--- a/klipper-types/src/load_cell_probe.rs
+++ b/klipper-types/src/load_cell_probe.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct LoadCellProbeStats {
+    #[serde(default)]
+    pub force_g: f64,
+
+    #[serde(default)]
+    pub min_force_g: f64,
+
+    #[serde(default)]
+    pub max_force_g: f64,
+
+    #[serde(default)]
+    pub is_calibrated: bool,
+
+    #[serde(default)]
+    pub counts_per_gram: f64,
+
+    #[serde(default)]
+    pub reference_tare_counts: f64,
+
+    #[serde(default)]
+    pub tare_counts: f64,
+
+    #[serde(default)]
+    pub tare_force: f64,
+
+    #[serde(default)]
+    pub last_trigger_time: f64,
+
+    #[serde(default)]
+    pub is_last_tap_valid: bool,
+
+    /// Captures unknown keys from newer Klipper/Kalico firmware versions.
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}

--- a/mamalluca/src/metrics/collectors/extruder.rs
+++ b/mamalluca/src/metrics/collectors/extruder.rs
@@ -50,14 +50,37 @@ impl MetricCollector for ExtruderCollector {
 
         // MPC for Kalico
         if let Some(control_stats) = stats.control_stats {
-            gauge!("klipper.stats.extruder.control_stats.filament_density", &labels).set(control_stats.filament_density);
-            gauge!("klipper.stats.extruder.control_stats.filament_heat_capacity", &labels).set(control_stats.filament_heat_capacity);
-            gauge!("klipper.stats.extruder.control_stats.loss_ambient", &labels).set(control_stats.loss_ambient);
-            gauge!("klipper.stats.extruder.control_stats.loss_filament", &labels).set(control_stats.loss_filament);
+            gauge!(
+                "klipper.stats.extruder.control_stats.filament_density",
+                &labels
+            )
+            .set(control_stats.filament_density);
+
+            gauge!(
+                "klipper.stats.extruder.control_stats.filament_heat_capacity",
+                &labels
+            )
+            .set(control_stats.filament_heat_capacity);
+
+            gauge!("klipper.stats.extruder.control_stats.loss_ambient", &labels)
+                .set(control_stats.loss_ambient);
+
+            gauge!(
+                "klipper.stats.extruder.control_stats.loss_filament",
+                &labels
+            )
+            .set(control_stats.loss_filament);
+
             gauge!("klipper.stats.extruder.control_stats.power", &labels).set(control_stats.power);
-            gauge!("klipper.stats.extruder.control_stats.temp_ambient", &labels).set(control_stats.temp_ambient);
-            gauge!("klipper.stats.extruder.control_stats.temp_block", &labels).set(control_stats.temp_block);
-            gauge!("klipper.stats.extruder.control_stats.temp_sensor", &labels).set(control_stats.temp_sensor);
+
+            gauge!("klipper.stats.extruder.control_stats.temp_ambient", &labels)
+                .set(control_stats.temp_ambient);
+
+            gauge!("klipper.stats.extruder.control_stats.temp_block", &labels)
+                .set(control_stats.temp_block);
+
+            gauge!("klipper.stats.extruder.control_stats.temp_sensor", &labels)
+                .set(control_stats.temp_sensor);
         }
 
         // `time_offset` is optional — only present in Kalico and some Klipper forks.

--- a/mamalluca/src/metrics/collectors/extruder.rs
+++ b/mamalluca/src/metrics/collectors/extruder.rs
@@ -48,6 +48,19 @@ impl MetricCollector for ExtruderCollector {
         gauge!("klipper.stats.extruder.target", &labels).set(stats.target);
         gauge!("klipper.stats.extruder.temperature", &labels).set(stats.temperature);
 
+        // MPC for Kalico
+        if let Some(control_stats) = stats.control_stats {
+            // let control_stats = stats.control_stats.unwrap();
+            gauge!("klipper.stats.extruder.control_stats.filament_density", &labels).set(control_stats.filament_density);
+            gauge!("klipper.stats.extruder.control_stats.filament_heat_capacity", &labels).set(control_stats.filament_heat_capacity);
+            gauge!("klipper.stats.extruder.control_stats.loss_ambient", &labels).set(control_stats.loss_ambient);
+            gauge!("klipper.stats.extruder.control_stats.loss_filament", &labels).set(control_stats.loss_filament);
+            gauge!("klipper.stats.extruder.control_stats.power", &labels).set(control_stats.loss_filament);
+            gauge!("klipper.stats.extruder.control_stats.temp_ambient", &labels).set(control_stats.temp_ambient);
+            gauge!("klipper.stats.extruder.control_stats.temp_block", &labels).set(control_stats.temp_block);
+            gauge!("klipper.stats.extruder.control_stats.temp_sensor", &labels).set(control_stats.temp_sensor);
+        }
+
         // `time_offset` is optional — only present in Kalico and some Klipper forks.
         if let Some(offset) = stats.time_offset {
             gauge!("klipper.stats.extruder.time_offset", &labels).set(offset);

--- a/mamalluca/src/metrics/collectors/extruder.rs
+++ b/mamalluca/src/metrics/collectors/extruder.rs
@@ -50,12 +50,11 @@ impl MetricCollector for ExtruderCollector {
 
         // MPC for Kalico
         if let Some(control_stats) = stats.control_stats {
-            // let control_stats = stats.control_stats.unwrap();
             gauge!("klipper.stats.extruder.control_stats.filament_density", &labels).set(control_stats.filament_density);
             gauge!("klipper.stats.extruder.control_stats.filament_heat_capacity", &labels).set(control_stats.filament_heat_capacity);
             gauge!("klipper.stats.extruder.control_stats.loss_ambient", &labels).set(control_stats.loss_ambient);
             gauge!("klipper.stats.extruder.control_stats.loss_filament", &labels).set(control_stats.loss_filament);
-            gauge!("klipper.stats.extruder.control_stats.power", &labels).set(control_stats.loss_filament);
+            gauge!("klipper.stats.extruder.control_stats.power", &labels).set(control_stats.power);
             gauge!("klipper.stats.extruder.control_stats.temp_ambient", &labels).set(control_stats.temp_ambient);
             gauge!("klipper.stats.extruder.control_stats.temp_block", &labels).set(control_stats.temp_block);
             gauge!("klipper.stats.extruder.control_stats.temp_sensor", &labels).set(control_stats.temp_sensor);

--- a/mamalluca/src/metrics/collectors/load_cell_probe.rs
+++ b/mamalluca/src/metrics/collectors/load_cell_probe.rs
@@ -1,0 +1,53 @@
+//! Collector for Kalico load_cell_probe statistics
+
+use mamalluca_macros::collector;
+use metrics::gauge;
+
+use super::labels_for;
+use crate::metrics::MetricCollector;
+
+#[collector(prefix = "load_cell_probe", named)]
+pub struct LoadCellProbeCollector;
+
+impl MetricCollector for LoadCellProbeCollector {
+    fn key_prefix(&self) -> &str {
+        Self::KEY_PREFIX
+    }
+
+    fn is_named(&self) -> bool {
+        Self::IS_NAMED
+    }
+
+    /// Deserialize and record load cell probe statistics.
+    ///
+    /// # Arguments
+    /// * `_key` - The full status key (unused; prefix matching already happened)
+    /// * `name` - Instance name (e.g. `"nextruder"`), `None` for the primary probe
+    /// * `data` - Raw JSON value from the status update
+    ///
+    /// # Errors
+    /// Returns an error if deserialization fails.
+    fn record(
+        &self,
+        _key: &str,
+        name: Option<&str>,
+        data: &serde_json::Value,
+    ) -> anyhow::Result<()> {
+        let stats: klipper_types::LoadCellProbeStats = serde_json::from_value(data.clone())?;
+        let labels = labels_for(name);
+
+        gauge!("klipper.stats.load_cell_probe.force_g", &labels).set(stats.force_g);
+        gauge!("klipper.stats.load_cell_probe.min_force_g", &labels).set(stats.min_force_g);
+        gauge!("klipper.stats.load_cell_probe.max_force_g", &labels).set(stats.max_force_g);
+        // Prometheus has no boolean type; represent as 0.0/1.0.
+        gauge!("klipper.stats.load_cell_probe.is_calibrated", &labels).set(stats.is_calibrated as u8 as f64);
+        gauge!("klipper.stats.load_cell_probe.counts_per_gram", &labels).set(stats.counts_per_gram);
+        gauge!("klipper.stats.load_cell_probe.reference_tare_counts", &labels).set(stats.reference_tare_counts);
+        gauge!("klipper.stats.load_cell_probe.tare_counts", &labels).set(stats.tare_counts);
+        gauge!("klipper.stats.load_cell_probe.tare_force", &labels).set(stats.tare_force);
+        gauge!("klipper.stats.load_cell_probe.last_trigger_time", &labels).set(stats.last_trigger_time);
+        gauge!("klipper.stats.load_cell_probe.is_last_tap_valid", &labels).set(stats.is_last_tap_valid as u8 as f64);
+
+        Ok(())
+    }
+}

--- a/mamalluca/src/metrics/collectors/load_cell_probe.rs
+++ b/mamalluca/src/metrics/collectors/load_cell_probe.rs
@@ -40,13 +40,20 @@ impl MetricCollector for LoadCellProbeCollector {
         gauge!("klipper.stats.load_cell_probe.min_force_g", &labels).set(stats.min_force_g);
         gauge!("klipper.stats.load_cell_probe.max_force_g", &labels).set(stats.max_force_g);
         // Prometheus has no boolean type; represent as 0.0/1.0.
-        gauge!("klipper.stats.load_cell_probe.is_calibrated", &labels).set(stats.is_calibrated as u8 as f64);
+        gauge!("klipper.stats.load_cell_probe.is_calibrated", &labels)
+            .set(stats.is_calibrated as u8 as f64);
         gauge!("klipper.stats.load_cell_probe.counts_per_gram", &labels).set(stats.counts_per_gram);
-        gauge!("klipper.stats.load_cell_probe.reference_tare_counts", &labels).set(stats.reference_tare_counts);
+        gauge!(
+            "klipper.stats.load_cell_probe.reference_tare_counts",
+            &labels
+        )
+        .set(stats.reference_tare_counts);
         gauge!("klipper.stats.load_cell_probe.tare_counts", &labels).set(stats.tare_counts);
         gauge!("klipper.stats.load_cell_probe.tare_force", &labels).set(stats.tare_force);
-        gauge!("klipper.stats.load_cell_probe.last_trigger_time", &labels).set(stats.last_trigger_time);
-        gauge!("klipper.stats.load_cell_probe.is_last_tap_valid", &labels).set(stats.is_last_tap_valid as u8 as f64);
+        gauge!("klipper.stats.load_cell_probe.last_trigger_time", &labels)
+            .set(stats.last_trigger_time);
+        gauge!("klipper.stats.load_cell_probe.is_last_tap_valid", &labels)
+            .set(stats.is_last_tap_valid as u8 as f64);
 
         Ok(())
     }

--- a/mamalluca/src/metrics/collectors/mod.rs
+++ b/mamalluca/src/metrics/collectors/mod.rs
@@ -8,6 +8,7 @@ pub mod bed;
 pub mod extruder;
 pub mod fan;
 pub mod heater_bed;
+pub mod load_cell_probe;
 pub mod mcu;
 pub mod moonraker;
 pub mod print;
@@ -16,7 +17,6 @@ pub mod stepper;
 pub mod system;
 pub mod temperature;
 pub mod toolhead;
-pub mod load_cell_probe;
 
 /// Build a Prometheus label vector with an optional instance name.
 ///

--- a/mamalluca/src/metrics/collectors/mod.rs
+++ b/mamalluca/src/metrics/collectors/mod.rs
@@ -16,6 +16,7 @@ pub mod stepper;
 pub mod system;
 pub mod temperature;
 pub mod toolhead;
+pub mod load_cell_probe;
 
 /// Build a Prometheus label vector with an optional instance name.
 ///


### PR DESCRIPTION
Pulls in stats for load_cell_probe (this can be a named type), and also extends extruder to optionally read MPC data.